### PR TITLE
Add ILS Approach Available Option to Airport Filtering

### DIFF
--- a/src/Popups/Settings.js
+++ b/src/Popups/Settings.js
@@ -334,6 +334,7 @@ function SettingsPopup(props) {
               <SettingSlider2 s={s} setS={(s) => {s.airport = _clone(s.airport); setS(s)}} label="Airport size (combined length of all runways in meters)" setting='airport.size' xs={12} />
               <SettingSlider3 s={s} setS={(s) => {s.airport = _clone(s.airport); setS(s)}} label="Airport longest runway (in feet)" setting="airport.runway" xs={12} />
               <SettingSelect s={s} setS={(s) => {s.airport = _clone(s.airport); setS(s)}} label="Airport runway surface" setting="airport.surface" options={surfaceOptions} multiple={true} xs={12} />
+              <SettingSwitch s={s} setS={(s) => {s.airport = _clone(s.airport); setS(s)}} label="ILS Approach Available" setting="airport.needsILS" xs={12} />
               <SettingSwitch s={s} setS={(s) => {s.airport = _clone(s.airport); setS(s)}} label="Only display and use simulator compatible airports" setting="airport.onlySim" xs={12} />
               <SettingSwitch s={s} setS={(s) => {s.airport = _clone(s.airport); setS(s)}} label="Only display airports that sell building materials" setting="airport.onlyBM" xs={12} />
             </Grid>

--- a/src/Routing.js
+++ b/src/Routing.js
@@ -374,7 +374,6 @@ const Routing = React.memo((props) => {
   const [overheadLength, setOverheadLength] = React.useState(props.options.settings.routeFinder.overheadLength);
   const [approachLength, setApproachLength] = React.useState(props.options.settings.routeFinder.approachLength);
   const [vipOnly, setVipOnly] = React.useState(false);
-  const [ilsApproachAvailable, setIlsApproachAvailable] = React.useState(false);
   const [loop, setLoop] = React.useState(false);
   const [type, setType] = React.useState('rent');
   const [minLoad, setMinLoad] = React.useState(props.options.settings.routeFinder.minLoad);
@@ -691,7 +690,7 @@ const Routing = React.memo((props) => {
     const jobsReverse = {};
     for (const k of [...new Set([...Object.keys(props.options.jobs), ...Object.keys(props.options.flight)])]) {
       const [fr, to] = k.split('-');
-      if (hideAirport(fr, props.options.settings.airport, props.options.settings.display.sim, ilsApproachAvailable) || hideAirport(to, props.options.settings.airport, props.options.settings.display.sim, ilsApproachAvailable)) { continue; }
+      if (hideAirport(fr, props.options.settings.airport, props.options.settings.display.sim) || hideAirport(to, props.options.settings.airport, props.options.settings.display.sim)) { continue; }
       const obj = {
         cargos: {
           TripOnly: [],
@@ -1691,12 +1690,6 @@ const Routing = React.memo((props) => {
               <FormControlLabel
                 control={<Switch checked={vipOnly} onChange={(evt) => setVipOnly(evt.target.checked)} />}
                 label="VIP jobs only"
-                className={classes.formLabel}
-              />
-
-              <FormControlLabel
-                control={<Switch checked={ilsApproachAvailable} onChange={(evt) => setIlsApproachAvailable(evt.target.checked)} />}
-                label="ILS Approach Available"
                 className={classes.formLabel}
               />
 

--- a/src/Routing.js
+++ b/src/Routing.js
@@ -374,6 +374,7 @@ const Routing = React.memo((props) => {
   const [overheadLength, setOverheadLength] = React.useState(props.options.settings.routeFinder.overheadLength);
   const [approachLength, setApproachLength] = React.useState(props.options.settings.routeFinder.approachLength);
   const [vipOnly, setVipOnly] = React.useState(false);
+  const [ilsApproachAvailable, setIlsApproachAvailable] = React.useState(false);
   const [loop, setLoop] = React.useState(false);
   const [type, setType] = React.useState('rent');
   const [minLoad, setMinLoad] = React.useState(props.options.settings.routeFinder.minLoad);
@@ -690,7 +691,7 @@ const Routing = React.memo((props) => {
     const jobsReverse = {};
     for (const k of [...new Set([...Object.keys(props.options.jobs), ...Object.keys(props.options.flight)])]) {
       const [fr, to] = k.split('-');
-      if (hideAirport(fr, props.options.settings.airport, props.options.settings.display.sim) || hideAirport(to, props.options.settings.airport, props.options.settings.display.sim)) { continue; }
+      if (hideAirport(fr, props.options.settings.airport, props.options.settings.display.sim, ilsApproachAvailable) || hideAirport(to, props.options.settings.airport, props.options.settings.display.sim, ilsApproachAvailable)) { continue; }
       const obj = {
         cargos: {
           TripOnly: [],
@@ -1690,6 +1691,12 @@ const Routing = React.memo((props) => {
               <FormControlLabel
                 control={<Switch checked={vipOnly} onChange={(evt) => setVipOnly(evt.target.checked)} />}
                 label="VIP jobs only"
+                className={classes.formLabel}
+              />
+
+              <FormControlLabel
+                control={<Switch checked={ilsApproachAvailable} onChange={(evt) => setIlsApproachAvailable(evt.target.checked)} />}
+                label="ILS Approach Available"
                 className={classes.formLabel}
               />
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,7 +1,7 @@
 import icaodata from "./data/icaodata-with-zones.json";
 import aircrafts from "./data/aircraft.json";
 
-export function hideAirport(icao, s, sim) {
+export function hideAirport(icao, s, sim, needsILS = false) {
   return (
       s
     &&
@@ -26,6 +26,12 @@ export function hideAirport(icao, s, sim) {
               s.onlyBM
             &&
               icaodata[icao].size < 5000
+          )
+        ||
+          (
+              needsILS
+            &&
+              (!icaodata[icao].hasILS || icaodata[icao].hasILS.length === 0)
           )
       )
   );

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,7 +1,7 @@
 import icaodata from "./data/icaodata-with-zones.json";
 import aircrafts from "./data/aircraft.json";
 
-export function hideAirport(icao, s, sim, needsILS = false) {
+export function hideAirport(icao, s, sim) {
   return (
       s
     &&
@@ -29,7 +29,7 @@ export function hideAirport(icao, s, sim, needsILS = false) {
           )
         ||
           (
-              needsILS
+              s.needsILS
             &&
               (!icaodata[icao].hasILS || icaodata[icao].hasILS.length === 0)
           )


### PR DESCRIPTION
I thought it would be useful to have an option to filter the route to airports that have an ILS approach available. This means you can find safe routes when conditions are bad.

I wrote a script that used my little navmap navigraph database (Which imported from MSFS2020) to populate the ILS Runway data. Not sure what your current data source is and the best way to make it easy to maintain if this is data you were interested in including.

Also my database was populated by MSFS data only, any airports that are only in other simulators have not been included. This may not be a big issue as I assume larger airports with ILS are more likely to be in both with same ident but I'm happy to look at including some extra data source if this is something you would like.

The script I used to update the data
https://gist.github.com/Lily418/02df70366356d124ca1ce8a50ce9be73

TODO:
- [ ] Determine best way to intergrate ILS Runway Data into your current data pipeline

