### PR TITLE
Pass actions to Result

### DIFF
--- a/src/Routing/Routing.js
+++ b/src/Routing/Routing.js
@@ -765,6 +765,7 @@ const Routing = React.memo((props) => {
             overheadLength={overheadLength}
             approachLength={approachLength}
             options={props.options}
+            actions={props.actions}
           />
 
         :


### PR DESCRIPTION
Fixes bug where clicking on the airport name in results would cause an exception.
See: https://github.com/piero-la-lune/FSE-Planner/blob/3c36b426818dda5defc97074eeb5e1dc56d534e0/src/Routing/Result.js#L231