### PR TITLE
FSE API Hits Counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "leaflet": "^1.9.4",
     "leaflet-polylinedecorator": "^1.6.0",
     "lodash": "^4.17.21",
+    "luxon": "^3.4.4",
     "lz-string": "^1.5.0",
     "maplibre-gl": "^2.4.0",
     "match-sorter": "^6.3.1",

--- a/src/MapLayers/CustomLayers/CustomLayerPopup.js
+++ b/src/MapLayers/CustomLayers/CustomLayerPopup.js
@@ -20,6 +20,7 @@ import RadioGroup from '@mui/material/RadioGroup';
 import { HexColorPicker, HexColorInput } from "react-colorful";
 
 import Storage from '../../Storage.js';
+import { apiHits } from "../../util/utility";
 import CommunityPopup from './CommunityPopup.js';
 import AreaPicker from './Components/AreaPicker.js';
 import SizePicker from './Components/SizePicker.js';
@@ -303,6 +304,9 @@ function CustomLayerPopup(props) {
     .catch(function(error) {
       alert(error);
       setLoading(false);
+    })
+    .finally(() => {
+      apiHits()
     });
   }
 

--- a/src/Popups/Update.js
+++ b/src/Popups/Update.js
@@ -37,7 +37,7 @@ import pointInPolygon from 'point-in-polygon';
 import CustomAreaPopup from './Components/CustomArea.js';
 import Storage from '../Storage.js';
 import log from '../util/logger.js';
-import { hideAirport, wrapNb } from "../util/utility.js";
+import { apiHits, hideAirport, wrapNb } from "../util/utility.js";
 
 import aircrafts from "../data/aircraft.json";
 
@@ -501,6 +501,9 @@ function UpdatePopup(props) {
       log.error("Error while updating Jobs", error);
       updateAlert(error);
       setLoading(false);
+    })
+    .finally(() => {
+      apiHits()
     });
   }
   // Save jobs
@@ -592,6 +595,9 @@ function UpdatePopup(props) {
       log.error("Error while updating Rentable Planes", error);
       updateAlert(error);
       setLoading(false);
+    })
+    .finally(() => {
+      apiHits()
     });
   }
   const updateOwnedPlanesRequest = (usernames, planes, callback) => {
@@ -621,6 +627,9 @@ function UpdatePopup(props) {
       log.error("Error while updating User Planes", error);
       updateAlert(error);
       setLoading(false);
+    })
+    .finally(() => {
+      apiHits()
     });
   }
   // Planes Update button clicked
@@ -710,6 +719,9 @@ function UpdatePopup(props) {
       log.error("Error while updating assignments", error);
       updateAlert(error);
       setLoading(false);
+    })
+    .finally(() => {
+      apiHits()
     });
   }
 

--- a/src/Popups/Update.js
+++ b/src/Popups/Update.js
@@ -397,7 +397,7 @@ function UpdatePopup(props) {
 
   const areas = React.useState(() => getAreas(props.icaodata, props.icaos))[0];
 
-  const hits= (storage.get('apiHits', [])).length
+  const [hits, setHits] = React.useState(0)
 
   // Update custom area when map center is updated
   React.useEffect(() => {
@@ -445,6 +445,8 @@ function UpdatePopup(props) {
     const layers = l.filter(elm => jl.includes(elm.id));
     setLayersOptions(l);
     setJobsLayers(layers);
+    apiHits(false); // remove old entries from counter on init
+    setHits((storage.get('apiHits', [])).length);
   }, [props.open, props.icaos, props.icaodata, props.settings.display.sim]);
 
   // Update the number of request for loading jobs each time one input changes
@@ -505,7 +507,7 @@ function UpdatePopup(props) {
       setLoading(false);
     })
     .finally(() => {
-      apiHits()
+      apiHits();
     });
   }
   // Save jobs
@@ -599,7 +601,7 @@ function UpdatePopup(props) {
       setLoading(false);
     })
     .finally(() => {
-      apiHits()
+      apiHits();
     });
   }
   const updateOwnedPlanesRequest = (usernames, planes, callback) => {
@@ -631,7 +633,7 @@ function UpdatePopup(props) {
       setLoading(false);
     })
     .finally(() => {
-      apiHits()
+      apiHits();
     });
   }
   // Planes Update button clicked
@@ -723,7 +725,7 @@ function UpdatePopup(props) {
       setLoading(false);
     })
     .finally(() => {
-      apiHits()
+      apiHits();
     });
   }
 

--- a/src/Popups/Update.js
+++ b/src/Popups/Update.js
@@ -397,6 +397,8 @@ function UpdatePopup(props) {
 
   const areas = React.useState(() => getAreas(props.icaodata, props.icaos))[0];
 
+  const hits= (storage.get('apiHits', [])).length
+
   // Update custom area when map center is updated
   React.useEffect(() => {
     const wrapZone = latlngs => {
@@ -788,6 +790,10 @@ function UpdatePopup(props) {
       <DialogContent dividers sx={{ p: 3 }}>
 
         <Alert severity="warning" sx={{ mb: 2 }}>You are limited to 40 requests every 6 hours (~1 request every 10 minutes).</Alert>
+
+        {!!hits && (
+          <Alert severity={hits > 34 ? 'error' : hits > 24 ? 'warning' : 'info'} sx={{ mb: 2 }}><span style={{fontWeight: 600}}>{hits}</span> request{hits !== 1 ? 's' : ''} in the past 6 hours</Alert>
+        )}
 
         <Box>
           <Accordion expanded={expanded === 'panel1'} onChange={panelChange('panel1')} data-tour="Step4">

--- a/src/util/utility.js
+++ b/src/util/utility.js
@@ -1,8 +1,10 @@
+import {DateTime} from "luxon";
 import icaodata from "../data/icaodata.json";
 import aircrafts from "../data/aircraft.json";
 
 import pointInPolygon from 'point-in-polygon';
 import { getDistance, getRhumbLineBearing, convertDistance } from "geolib";
+import Storage from "../Storage";
 
 export function hideAirport(icao, s, sim) {
   return (
@@ -266,7 +268,14 @@ export function toLatLngs(str) {
   return null;
 }
 
-// Transform a latitute and longitude into a text GPS coordinates
+// Transform a latitude and longitude into a text GPS coordinates
 export function formatGPSCoord(lat, lng) {
   return Math.abs(lat)+(lat >= 0 ? 'N' : 'S')+' '+Math.abs(lng)+(lng >= 0 ? 'E' : 'W');
+}
+
+// increments fse api hits counter
+export function apiHits(){
+  const storage= new Storage()
+  const hits = storage.get('apiHits', [])?.filter(hit=> DateTime.now().diff(DateTime.fromMillis(hit), 'hours').hours < 7)
+  storage.set('apiHits', [...hits, DateTime.now().valueOf()])
 }

--- a/src/util/utility.js
+++ b/src/util/utility.js
@@ -274,8 +274,12 @@ export function formatGPSCoord(lat, lng) {
 }
 
 // increments fse api hits counter
-export function apiHits(){
-  const storage= new Storage()
-  const hits = storage.get('apiHits', [])?.filter(hit=> DateTime.now().diff(DateTime.fromMillis(hit), 'hours').hours < 7)
-  storage.set('apiHits', [...hits, DateTime.now().valueOf()])
+export function apiHits(increment = true){
+  const storage= new Storage();
+  const hits = storage.get('apiHits', [])?.filter(hit => DateTime.now().diff(DateTime.fromMillis(hit), 'hours').hours < 7);
+  if (increment) {
+    storage.set('apiHits', [...hits, DateTime.now().valueOf()]);
+    return;
+  }
+  storage.set('apiHits', [...hits]);
 }


### PR DESCRIPTION
### Use case
I, as an user, wanna to know how many requests was sent to FSE API in past 6 hours to stick with FSE User Guide related to the use of API.

### Proposed solution
This PR implements a counter to accumulate the total quantity of requests sent to FSE API. Also, displays this information in Update screen with 3 levels of severities.
![Captura de Tela 2023-11-30 às 05 21 28](https://github.com/piero-la-lune/FSE-Planner/assets/1750415/9fb61443-2e12-4ca6-b9df-01303621a41e)
_Total of requests to FSE API up to 24 requests in past 6 hours_

![Captura de Tela 2023-11-30 às 05 30 17](https://github.com/piero-la-lune/FSE-Planner/assets/1750415/c51956ec-ab19-41e8-864d-3ef077363727)
_Total of requests to FSE API from 25 to 34 requests in past 6 hours_

![Captura de Tela 2023-11-30 às 05 30 52](https://github.com/piero-la-lune/FSE-Planner/assets/1750415/7c00b8e4-1986-4f05-826a-0e58b72f5fe7)
_Total of requests to FSE API with more than 34 requests in past 6 hours_