### PR TITLE
Fix pay per leg

### DIFF
--- a/src/Routing/Routing.js
+++ b/src/Routing/Routing.js
@@ -266,7 +266,7 @@ const Routing = React.memo((props) => {
       }
 
       allResults[i].payNM = pay/totalDistance;
-      allResults[i].payLeg = pay/allResults[i].icaos.length;
+      allResults[i].payLeg = pay / (allResults[i].icaos.length - 1);
       allResults[i].payTime = pay/time;
       allResults[i].time = h+'H'+(min > 9 ? min : "0"+min);
       allResults[i].timeNb = time;


### PR DESCRIPTION
Thank you so much for this wonderful tool!

"Pay per leg" took into account one leg too much.

`icaos` always has a length of >= 2, so we do not have to check for division by zero.