### PR TITLE
Keep Load Data window open while updating.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,6 @@
       "last 1 safari version"
     ]
   },
-  "homepage": "."
+  "homepage": ".",
+  "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a"
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,5 @@
       "last 1 safari version"
     ]
   },
-  "homepage": ".",
-  "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a"
+  "homepage": "."
 }

--- a/src/App.js
+++ b/src/App.js
@@ -118,6 +118,7 @@ const defaultSettings = {
     jobsPlanesRequests: 1,
     jobsPlanesMax: 10,
     express: true,
+    persist: false,
     expiration: ''
   },
   filters: {

--- a/src/Popups/Settings.js
+++ b/src/Popups/Settings.js
@@ -430,6 +430,7 @@ function SettingsPopup(props) {
               </Grid>
               <Grid container spacing={3} sx={{ mt: 2 }}>
                 <SettingSelect s={s} setS={setS} label="Job direction for the selected area/layer" setting='update.direction' xs={6} options={directionOptions} />
+                <SettingSwitch s={s} setS={setS} label="Keep window open after updating" setting='update.persist' xs={6} />
               </Grid>
               <Grid container spacing={3} sx={{ mt: 2 }}>
                 <SettingSelect s={s} setS={setS} label="Load area around available planes" setting='update.jobsPlanes' xs={12} options={jobsPlanesOptions} />

--- a/src/Popups/Update.js
+++ b/src/Popups/Update.js
@@ -394,6 +394,8 @@ function UpdatePopup(props) {
   const [layersOptions, setLayersOptions] = React.useState([]);
   const [jobsLayers, setJobsLayers] = React.useState([]);
   const { readString } = usePapaParse();
+  const { persist } = props.settings.update;
+
 
   const areas = React.useState(() => getAreas(props.icaodata, props.icaos))[0];
 
@@ -525,7 +527,11 @@ function UpdatePopup(props) {
     storage.set('jobsLayers', jobsLayers.map(elm => elm.id));
     // Close popup
     setLoading(false);
-    handleClose();
+    if ( ! persist ) {
+      handleClose();
+    } else {
+      setExpanded(false);
+    }
   }
   // Jobs Update button clicked
   const updateJobs = (evt) => {
@@ -568,7 +574,9 @@ function UpdatePopup(props) {
     setJobsTime(null);
     // Close popup
     setLoading(false);
-    handleClose();
+    if ( ! persist ) {
+      handleClose();
+    }
   }
 
   // Loop function to get planes from FSE
@@ -669,7 +677,11 @@ function UpdatePopup(props) {
         storage.set('planeUser', planeUser);
         // Close popup
         setLoading(false);
-        handleClose();
+        if ( ! persist ) {
+          handleClose();
+        } else {
+          setExpanded(false);
+        }
       });
     });
   }
@@ -684,7 +696,9 @@ function UpdatePopup(props) {
     setPlanesTime(null);
     // Close popup
     setLoading(false);
-    handleClose();
+    if ( ! persist ) {
+      handleClose();
+    }
   }
 
   // Loop function to get assignments from FSE
@@ -744,7 +758,11 @@ function UpdatePopup(props) {
       setFlightTime(date);
       // Close popup
       setLoading(false);
-      handleClose();
+      if ( ! persist ) {
+        handleClose();
+      } else {
+        setExpanded(false);
+      }
     });
   }
   // My assignments Clear button clicked
@@ -758,7 +776,9 @@ function UpdatePopup(props) {
     setFlightTime(null);
     // Close popup
     setLoading(false);
-    handleClose();
+    if ( ! persist ) {
+      handleClose();
+    }
   }
 
   const panelChange = (panel) => (event, isExpanded) => {


### PR DESCRIPTION
Adds a setting to keep the modal open while updating data.  It also closes the accordion after updating, but not after clearing data since updating is *likely* to be the next step.