### PR TITLE
Add AW109SP and C408

### DIFF
--- a/src/data/aircraft.json
+++ b/src/data/aircraft.json
@@ -62,6 +62,15 @@
     "fuelType": 1,
     "maxKg": 1846
   },
+  "Agusta Westwind AW109SP (X-Trident)": {
+    "maxPax": 7,
+    "maxCargo": 1048,
+    "fuelCapacity": 215,
+    "speed": 158,
+    "GPH": 60,
+    "fuelType": 1,
+    "maxKg": 1048
+  },
   "Airbus A320": {
     "maxPax": 149,
     "maxCargo": 30279,

--- a/src/data/aircraft.json
+++ b/src/data/aircraft.json
@@ -1115,6 +1115,15 @@
     "fuelType": 0,
     "maxKg": 1541
   },
+  "Cessna 408 SkyCourier": {
+    "maxPax": 19,
+    "maxCargo": 2950,
+    "fuelCapacity": 720,
+    "speed": 210,
+    "GPH": 100,
+    "fuelType": 1,
+    "maxKg": 2950
+  },
   "Cessna 414A Chancellor": {
     "maxPax": 7,
     "maxCargo": 1007,


### PR DESCRIPTION
Hi piero and thank you very much for your valuable tool!

This adds the 2 new aircraft Agusta Westwind AW109SP (X-Trident) and Cessna 408 SkyCourier.

Raw data:
```
<AircraftConfig>
<MakeModel>Agusta Westwind AW109SP (X-Trident)</MakeModel>
<Crew>0</Crew>
<Seats>8</Seats>
<CruiseSpeed>158</CruiseSpeed>
<GPH>60</GPH>
<FuelType>1</FuelType>
<MTOW>3175</MTOW>
<EmptyWeight>2050</EmptyWeight>
<Price>303780.00</Price>
<Ext1>0</Ext1>
<LTip>0</LTip>
<LAux>41</LAux>
<LMain>35</LMain>
<Center1>83</Center1>
<Center2>0</Center2>
<Center3>0</Center3>
<RMain>29</RMain>
<RAux>27</RAux>
<RTip>0</RTip>
<Ext2>0</Ext2>
<Engines>2</Engines>
<EnginePrice>114400.00</EnginePrice>
<ModelId>406</ModelId>
<MaxCargo>1048</MaxCargo>
</AircraftConfig>
```

```
<AircraftConfig>
<MakeModel>Cessna 408 SkyCourier</MakeModel>
<Crew>0</Crew>
<Seats>20</Seats>
<CruiseSpeed>210</CruiseSpeed>
<GPH>100</GPH>
<FuelType>1</FuelType>
<MTOW>8618</MTOW>
<EmptyWeight>5591</EmptyWeight>
<Price>1134300.00</Price>
<Ext1>0</Ext1>
<LTip>0</LTip>
<LAux>0</LAux>
<LMain>360</LMain>
<Center1>0</Center1>
<Center2>0</Center2>
<Center3>0</Center3>
<RMain>360</RMain>
<RAux>0</RAux>
<RTip>0</RTip>
<Ext2>0</Ext2>
<Engines>2</Engines>
<EnginePrice>114400.00</EnginePrice>
<ModelId>407</ModelId>
<MaxCargo>2950</MaxCargo>
</AircraftConfig>
```


I deducted from other entries that `maxKg` for FSE planner is `MTOW - EmptyWeight - 77kg (1 pilot)`.
